### PR TITLE
Fix JS file call ordrer in markdown.html MDEDITOR_LANGUAGE to work

### DIFF
--- a/flask_mdeditor/templates/markdown.html
+++ b/flask_mdeditor/templates/markdown.html
@@ -38,13 +38,13 @@
   <textarea {{ final_attrs|safe }}>{{ value }}</textarea>
 </div>
 
+<script src="{{ url_for('mdeditor.static', filename='mdeditor/js/jquery.min.js', _external=True) }}"></script>
+<script src="{{ url_for('mdeditor.static', filename='mdeditor/js/editormd.min.js', _external=True) }}"></script>
 {% if mdeditor_config.language == 'en' %}
 <script src="{{ url_for('mdeditor.static', filename='mdeditor/languages/en.js') }}"></script>
 {% elif mdeditor_config.language == 'de' %}
 <script src="{{ url_for('mdeditor.static', filename='mdeditor/languages/de.js') }}"></script>
 {% endif %}
-<script src="{{ url_for('mdeditor.static', filename='mdeditor/js/jquery.min.js', _external=True) }}"></script>
-<script src="{{ url_for('mdeditor.static', filename='mdeditor/js/editormd.min.js', _external=True) }}"></script>
 <script type="text/javascript">
     $(function () {
         editormd("wmd-wrapper", {


### PR DESCRIPTION
Hi ! 

I had some trouble making the language option to work. I wasn't able to change the default value from ZH to EN. 
It was because JS wasn't called on the right order. 

This PR will fix this problem. 