### PR TITLE
Add a configuration option for line wrapping

### DIFF
--- a/flask_mdeditor/__init__.py
+++ b/flask_mdeditor/__init__.py
@@ -50,7 +50,7 @@ class _MDEditor():
             'sequence': True,
             'language': current_app.config.get("MDEDITOR_LANGUAGE",'zh'),  # zh / en
             'watch': True,  # Live preview
-            'lineWrapping': False,  # lineWrapping
+            'lineWrapping': current_app.config.get('MDEDITOR_WRAPPING','False'),  # lineWrapping
             'lineNumbers': False  # lineNumbers
         }
         return DEFAULT_CONFIG


### PR DESCRIPTION
Change from a fixed default to a configurable option by adding:

app.config['MDEDITOR_WRAPPING'] = 'True' 

to flask application.